### PR TITLE
added min throttle value to mapping

### DIFF
--- a/crates/src-tauri/src/events/action.rs
+++ b/crates/src-tauri/src/events/action.rs
@@ -3,14 +3,14 @@ use simconnect::SimConnector;
 pub struct Action {
     pub id: u32,
     pub name: ActionName,
-    pub excecute_action: Box<dyn Fn(&SimConnector, String)>,
+    pub excecute_action: Box<dyn Fn(&SimConnector, String, f32)>,
 }
 
 impl Action {
     pub const fn new(
         id: u32,
         name: ActionName,
-        excecute_action: Box<dyn Fn(&SimConnector, String)>,
+        excecute_action: Box<dyn Fn(&SimConnector, String, f32)>,
     ) -> Action {
         Action {
             id,
@@ -19,8 +19,8 @@ impl Action {
         }
     }
 
-    pub fn excecute_action(&self, connector: &SimConnector, input: String) {
-        (self.excecute_action)(connector, input)
+    pub fn excecute_action(&self, connector: &SimConnector, input: String, modifier: f32) {
+        (self.excecute_action)(connector, input, modifier)
     }
 }
 

--- a/crates/src-tauri/src/events/action_registry.rs
+++ b/crates/src-tauri/src/events/action_registry.rs
@@ -3,16 +3,24 @@ use std::collections::HashMap;
 use super::{action::Action, actions::get_actions};
 pub struct ActionRegistry {
     actions: HashMap<u32, Action>,
+    pub min_throttle: f32,
 }
 
 impl ActionRegistry {
     pub fn new() -> ActionRegistry {
         let actions = get_actions();
-        ActionRegistry { actions }
+        ActionRegistry {
+            actions,
+            min_throttle: 0.0,
+        }
     }
 
     pub fn load_actions(&mut self) {
         self.actions = get_actions();
+    }
+
+    pub fn set_min_throttle(&mut self, min_throttle: f32) {
+        self.min_throttle = min_throttle;
     }
 
     pub fn get_action_by_id(&self, id: u32) -> Option<&Action> {

--- a/crates/src-tauri/src/events/actions.rs
+++ b/crates/src-tauri/src/events/actions.rs
@@ -6,25 +6,27 @@ use crate::sim_utils::input_converters::map_analog_to_axis;
 
 use super::action::{Action, ActionName};
 
-fn throttle_action(connector: &SimConnector, values: String) {
+fn throttle_action(connector: &SimConnector, values: String, modifier: f32) {
     // The throttle action is received as a string of 5 values separated by spaces
     // The first value is the Id of the action
     // The 2nd, 3th, 4th and 5th values are the throttle values for the engines
     let values: Vec<&str> = values.split(' ').collect();
+
+    println!("modifier: {}", modifier);
 
     // The event id of the first engine = 207 we can add 1 to get the event id of the other engines
     for (index, value) in values.iter().skip(1).enumerate() {
         connector.transmit_client_event(
             0,
             207 + index as u32,
-            map_analog_to_axis(value.parse::<i32>().unwrap()) as DWORD,
+            map_analog_to_axis(modifier, value.parse::<i32>().unwrap()) as DWORD,
             simconnect::SIMCONNECT_GROUP_PRIORITY_HIGHEST,
             simconnect::SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY,
         );
     }
 }
 
-fn mixture_action(connector: &SimConnector, values: String) {
+fn mixture_action(connector: &SimConnector, values: String, _modifier: f32) {
     // The mixture action is received as a string of 5 values separated by spaces
     // The first value is the Id of the action
     // The 2nd, 3th, 4th, 5th values are the mixture values for the engines
@@ -37,14 +39,14 @@ fn mixture_action(connector: &SimConnector, values: String) {
         connector.transmit_client_event(
             0,
             211 + index as u32,
-            map_analog_to_axis(value.parse::<i32>().unwrap()) as DWORD,
+            map_analog_to_axis(0.0, value.parse::<i32>().unwrap()) as DWORD,
             simconnect::SIMCONNECT_GROUP_PRIORITY_HIGHEST,
             simconnect::SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY,
         );
     }
 }
 
-fn propeller_action(connector: &SimConnector, values: String) {
+fn propeller_action(connector: &SimConnector, values: String, _modifier: f32) {
     // The propeller action is received as a string of 5 values separated by spaces
     // The first value is the Id of the action
     // The 2nd, 3th, 4th, 5th values are the propeller values for the engines
@@ -54,7 +56,7 @@ fn propeller_action(connector: &SimConnector, values: String) {
         connector.transmit_client_event(
             0,
             215 + index as u32,
-            map_analog_to_axis(value.parse::<i32>().unwrap()) as DWORD,
+            map_analog_to_axis(0.0, value.parse::<i32>().unwrap()) as DWORD,
             simconnect::SIMCONNECT_GROUP_PRIORITY_HIGHEST,
             simconnect::SIMCONNECT_EVENT_FLAG_GROUPID_IS_PRIORITY,
         );

--- a/crates/src-tauri/src/events/outputs.json
+++ b/crates/src-tauri/src/events/outputs.json
@@ -45,6 +45,15 @@
     "category": "Environment"
   },
   {
+    "simvar": "THROTTLE LOWER LIMIT",
+    "metric": "Percent Over 100",
+    "update_every": 0.01,
+    "cb_text": "Throttle lower limit",
+    "id": 655,
+    "output_type": "percentage",
+    "category": "Engines"
+  },
+  {
     "simvar": "PLANE HEADING DEGREES GYRO",
     "metric": "Degrees",
     "update_every": 0.1,

--- a/crates/src-tauri/src/sim_utils/input_converters.rs
+++ b/crates/src-tauri/src/sim_utils/input_converters.rs
@@ -12,12 +12,13 @@ pub fn convert_dec_to_dcb(val: u32) -> u32 {
     result
 }
 
-pub fn map_analog_to_axis(val: i32) -> i32 {
-    let analog_min = 0;
-    let analog_max = 1023;
+pub fn map_analog_to_axis(min: f32, val: i32) -> i32 {
+    let analog_min = 0.0;
+    let analog_max = 1023.0;
 
-    let axis_min = -16383;
-    let axis_max = 16383;
+    let axis_min = -16383.0 - (-16383.0 * min);
+    let axis_max = 16383.0;
+    let conv_val = val as f32;
 
-    axis_min + (axis_max - axis_min) * (val - analog_min) / (analog_max - analog_min)
+    (axis_min + (axis_max - axis_min) * (conv_val - analog_min) / (analog_max - analog_min)) as i32
 }

--- a/crates/src-tauri/src/simconnect_mod/wasm.rs
+++ b/crates/src-tauri/src/simconnect_mod/wasm.rs
@@ -80,7 +80,6 @@ fn create_wasm_client(
 
 pub fn register_wasm_event(conn: &mut simconnect::SimConnector, event: WasmEvent) {
     let event_json = serde_json::to_string(&event).unwrap();
-    println!("event json: {:?}", event_json);
     send_wasm_command(conn, event_json.as_str());
 }
 


### PR DESCRIPTION
<!---
Before submitting a pull request

Make sure you ran the following commands

If you worked on Rust code
- cargo fmt
- cargo clippy
- cargo build

If you worked on Typescript code
- npm run format
- npm run build

Give the pull request a descriptive title. Make sure to include an issue number if fixing a bug linked to an open issue in the title.
-->

## What kind of change is in this PR

- [x] New feature
- [ ] Bug fix
- [ ] Documentation

---

## What's changed

_Provide a description of the changes you've made and why you made them._
- Throttle range gets automatically mapped based on the aircraft (to calculate for reversers)
- When you swap aircraft the min throttle value is set to the new value
---

## Related issue

_If applicable provide the issue number._

---

## Checklist before merging

- [ ] If it's a core feature I've assessed if tests are needed and implemented
- [ ] I ran linting and formatting
- [ ] I checked if the project still builds
