### PR TITLE
fixed saving of update_every as string

### DIFF
--- a/crates/connector/src-tauri/tauri.conf.json
+++ b/crates/connector/src-tauri/tauri.conf.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.6",
+  "version": "0.9.7",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm run build",

--- a/frontend/pages/custom_output_page/components/WasmEventRowEditor.tsx
+++ b/frontend/pages/custom_output_page/components/WasmEventRowEditor.tsx
@@ -39,6 +39,10 @@ export const WasmEventRowEditor = ({
       setWasmEvent({ ...wasmEvent, plane_or_category: parsedValue });
       return;
     }
+    if (key === "update_every") {
+      setWasmEvent({ ...wasmEvent, update_every: parseFloat(value) });
+      return;
+    }
     if (key === "id") {
       if (value !== originalEvent.id.toString()) {
         const idState = await validateEventID(value);


### PR DESCRIPTION
<!---
Before submitting a pull request

Make sure you ran the following commands

If you worked on Rust code
- cargo fmt
- cargo clippy
- cargo build

If you worked on Typescript code
- npm run format
- npm run build

Give the pull request a descriptive title. Make sure to include an issue number if fixing a bug linked to an open issue in the title.
-->

## What kind of change is in this PR

- [ ] New feature
- [x] Bug fix
- [ ] Documentation

---

## What's changed

_Provide a description of the changes you've made and why you made them._

## Connector

### What's fixed:
- Saving update every value changes would save as string instead of number
- Loading string update every could cause issues in the custom output menu
---

## Related issue

_If applicable provide the issue number._

---

## Checklist before merging

- [ ] If it's a core feature I've assessed if tests are needed and implemented
- [ ] I ran linting and formatting
- [ ] I checked if the project still builds
