### PR TITLE
Vertical speed fix

### DIFF
--- a/crates/connector/src-tauri/connector_library/BitsAndDroidsFlightConnector.cpp
+++ b/crates/connector/src-tauri/connector_library/BitsAndDroidsFlightConnector.cpp
@@ -516,7 +516,18 @@ void BitsAndDroidsFlightConnector::switchHandling() {
     trueVerticalSpeed = cutValue.toInt();
     break;
   }
-
+  case 331: {
+    velocityBodyX = cutValue.toInt();
+    break;
+  }
+  case 332: {
+    velocityBodyY = cutValue.toInt();
+    break;
+  }
+  case 341: {
+    velocityBodyZ = cutValue.toInt();
+    break;
+  }
   case 326: {
     indicatedAirspeed = cutValue.toInt();
     break;
@@ -529,7 +540,6 @@ void BitsAndDroidsFlightConnector::switchHandling() {
     indicatedAltitude2 = cutValue.toInt();
     break;
   }
-
   case 337: {
     kohlmanAltimeter = cutValue.toInt();
     break;

--- a/crates/connector/src-tauri/connector_library/BitsAndDroidsFlightConnector.h
+++ b/crates/connector/src-tauri/connector_library/BitsAndDroidsFlightConnector.h
@@ -707,6 +707,9 @@ public:
   int getIndicatedAltitudeCalibrated() { return indicatedAltitudeCalibrated; };
   int getIndicatedHeading() { return indicatedHeading; };
   int getIndicatedGPSGroundspeed() { return indicatedGPSGroundspeed; };
+  int getVelocityBodyX() { return velocityBodyX; };
+  int getVelocityBodyY() { return velocityBodyY; };
+  int getVelocityBodyZ() { return velocityBodyZ; };
   int getTrueVerticalSpeed() { return trueVerticalSpeed; };
   int getLastPrefix();
 
@@ -937,6 +940,9 @@ private:
   int indicatedAltitudeCalibrated;
   int indicatedHeading;
   int indicatedGPSGroundspeed;
+  int velocityBodyX;
+  int velocityBodyY;
+  int velocityBodyZ;
   int trueVerticalSpeed;
 
   int headingGyro;

--- a/crates/connector/src-tauri/src/events/outputs.json
+++ b/crates/connector/src-tauri/src/events/outputs.json
@@ -469,10 +469,37 @@
   },
   {
     "simvar": "VERTICAL SPEED",
-    "metric": "Feet per second",
+    "metric": "Feet per minute",
     "update_every": 10,
     "cb_text": "Vertical speed",
     "id": 330,
+    "output_type": "integer",
+    "category": "Data"
+  },
+  {
+    "simvar": "VELOCITY BODY X",
+    "metric": "Feet per minute",
+    "update_every": 10,
+    "cb_text": "Velocity body x",
+    "id": 331,
+    "output_type": "integer",
+    "category": "Data"
+  },
+  {
+    "simvar": "VELOCITY BODY Y",
+    "metric": "Feet per minute",
+    "update_every": 10,
+    "cb_text": "Velocity body y",
+    "id": 332,
+    "output_type": "integer",
+    "category": "Data"
+  },
+  {
+    "simvar": "VELOCITY BODY Z",
+    "metric": "Feet per minute",
+    "update_every": 10,
+    "cb_text": "Velocity body z",
+    "id": 341,
     "output_type": "integer",
     "category": "Data"
   },

--- a/crates/connector/src-tauri/tauri.conf.json
+++ b/crates/connector/src-tauri/tauri.conf.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.11",
+  "version": "0.10.0",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm run build",


### PR DESCRIPTION
<!---
Before submitting a pull request

Make sure you ran the following commands

If you worked on Rust code
- cargo fmt
- cargo clippy
- cargo build

If you worked on Typescript code
- npm run format
- npm run build

Give the pull request a descriptive title. Make sure to include an issue number if fixing a bug linked to an open issue in the title.
-->

## What kind of change is in this PR

- [x] New feature
- [x] Bug fix
- [ ] Documentation

---

## What's changed

### Connector:
- Added velocity body X simvar (feet per minute)
- Added velocity body Y simvar (feet per minute)
- Added velocity body Z simvar (feet per minute)

### Library:
- Added getVelocityBodyX()
- Added getVelocityBodyY()
- Added getVelocityBodyZ()

## What's fixed:
- Vertical speed now returns values (feet per minute). Due to incorrect documentation of the sim SDK, the value used to be requested in feet per seconds.

## Bugfixes
_Provide a description of the changes you've made and why you made them._

---

## Related issue

_If applicable provide the issue number._
#302
---

## Checklist before merging

- [ ] If it's a core feature I've assessed if tests are needed and implemented
- [ ] I ran linting and formatting
- [ ] I checked if the project still builds
